### PR TITLE
fix ReadMeans’ accessing 50 bytes in a region of size 6 [-Wstringop-o…

### DIFF
--- a/src/libphylocom/io.c
+++ b/src/libphylocom/io.c
@@ -126,7 +126,7 @@ void NAF(phylo P[], sample S, traits T)
 
 // ---------- READ MEANS -----------------------------------------------------
 
-means ReadMeans(phylo Intree, char meansfile[50])
+means ReadMeans(phylo Intree, char meansfile[6])
 {
 
   char line[500];

--- a/src/libphylocom/phylocom.h
+++ b/src/libphylocom/phylocom.h
@@ -262,7 +262,7 @@ struct phylo New2fy(char[50]);
 void Fy2new(phylo);
 struct sample ReadSample(char[50]);
 struct phylo ReadPhylogeny(char[50]);
-struct means ReadMeans(phylo, char[50]);
+struct means ReadMeans(phylo, char[6]);
 void AttachSampleToPhylo(sample, phylo, int *);
 void AttachSampleToTraits(sample, traits, int *);
 void AttachTraitsToPhylo(traits, phylo, int *);


### PR DESCRIPTION
…verflow=]

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
